### PR TITLE
chore: add docker build and push action

### DIFF
--- a/.github/workflows/push-docker-image.yaml
+++ b/.github/workflows/push-docker-image.yaml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - djh/push-docker-image-to-github-registry # remove before merge pls
 
 jobs:
   docker:

--- a/.github/workflows/push-docker-image.yaml
+++ b/.github/workflows/push-docker-image.yaml
@@ -1,0 +1,42 @@
+name: build and push docker image
+
+# Build and push a Docker image used by `v3-e2e-testing`.
+# This is pushed to the internal Github Container Registry.
+
+on:
+  push:
+    branches:
+      - main
+      - djh/push-docker-image-to-github-registry # remove before merge pls
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry 📦
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+        continue-on-error: true
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64, linux/arm64
+          push: true
+          tags: ghcr.io/hasura/ndc-clickhouse:latest, ghcr.io/hasura/ndc-clickhouse:${{ github.sha }},
+


### PR DESCRIPTION
We'd like to test `ndc-clickhouse` with the e2e tests, therefore this PR adds a Github action that builds and pushes a Docker image on each commit to `main`. We use the Github repository so the image is not publicly accessible.

This image takes a long time to build because we build it for `amd64` and `arm64`. Since this connector isn't currently under active development, this feels acceptable to me for now, we can always revisit it.