### PR TITLE
fix ordering of result sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3]
+
+- Fix ordering of result sets for foreach queries (remote joins)
+
 ## [0.2.2]
 
 - Return error if empty list of query variables passed. Variables should be ommited or be a list with at least one member

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ checksum = "97af0562545a7d7f3d9222fcf909963bec36dcb502afaacab98c6ffac8da47ce"
 
 [[package]]
 name = "common"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "peg",
  "reqwest 0.12.3",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-clickhouse"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "common",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-clickhouse-cli"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "clap",
  "common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,5 @@ members = [
 ]
 resolver = "2"
 
-package.version = "0.2.2"
+package.version = "0.2.3"
 package.edition = "2021"

--- a/crates/ndc-clickhouse/src/sql/query_builder.rs
+++ b/crates/ndc-clickhouse/src/sql/query_builder.rs
@@ -193,7 +193,7 @@ impl<'r, 'c> QueryBuilder<'r, 'c> {
         let order_by = if self.request.variables.is_some() {
             vec![OrderByExpr {
                 expr: Expr::CompoundIdentifier(vec![
-                    Ident::new_quoted("_rowset"),
+                    Ident::new_quoted("_vars"),
                     Ident::new_quoted("_varset_id"),
                 ]),
                 asc: Some(true),


### PR DESCRIPTION
Fix an issue where ordering of result sets was incorrect.

We should order on `_vars._varset_id`, which cannot be null, instead of `_row._varset_id`

This manifested as empty results showing up last, which meant the wrong result was returned.