### PR TITLE
remove error handling for invalid foreach requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4]
+
+- Allow explain of invalid foreach queries. Will generate invalid SQL, for proper execution these should be parameterized
+
 ## [0.2.3]
 
 - Fix ordering of result sets for foreach queries (remote joins)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ checksum = "97af0562545a7d7f3d9222fcf909963bec36dcb502afaacab98c6ffac8da47ce"
 
 [[package]]
 name = "common"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "peg",
  "reqwest 0.12.3",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-clickhouse"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "async-trait",
  "common",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-clickhouse-cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "clap",
  "common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,5 @@ members = [
 ]
 resolver = "2"
 
-package.version = "0.2.3"
+package.version = "0.2.4"
 package.edition = "2021"

--- a/crates/ndc-clickhouse/src/sql/query_builder.rs
+++ b/crates/ndc-clickhouse/src/sql/query_builder.rs
@@ -111,9 +111,6 @@ impl<'r, 'c> QueryBuilder<'r, 'c> {
         };
 
         let with = if let Some(variables) = &self.request.variables {
-            if variables.is_empty() {
-                return Err(QueryBuilderError::EmptyQueryVariablesList);
-            }
             let mut variable_values: IndexMap<String, Vec<serde_json::Value>> = IndexMap::new();
 
             variable_values.insert(
@@ -1658,7 +1655,6 @@ impl<'r, 'c> QueryBuilder<'r, 'c> {
             }
         }
     }
-
     fn collection_relationship(
         &self,
         relationship: &str,

--- a/crates/ndc-clickhouse/src/sql/query_builder/error.rs
+++ b/crates/ndc-clickhouse/src/sql/query_builder/error.rs
@@ -28,8 +28,6 @@ pub enum QueryBuilderError {
     Unexpected(String),
     /// There was an issue creating typecasting strings
     Typecasting(String),
-    /// An empty list of variables was passed. If variables are passed, we expect at least one set.
-    EmptyQueryVariablesList,
 }
 
 impl fmt::Display for QueryBuilderError {
@@ -66,10 +64,6 @@ impl fmt::Display for QueryBuilderError {
             QueryBuilderError::NotSupported(e) => write!(f, "Not supported: {e}"),
             QueryBuilderError::Unexpected(e) => write!(f, "Unexpected: {e}"),
             QueryBuilderError::Typecasting(e) => write!(f, "Typecasting: {e}"),
-            QueryBuilderError::EmptyQueryVariablesList => write!(
-                f,
-                "Empty query variables list: we expect at least one set, or no list."
-            ),
         }
     }
 }


### PR DESCRIPTION
This PR remove error handling for invalid foreach requests
Specifically, requests with an empty variable set will no longer result in an error.

They will instead fail on database execution, with a SQL error.

This PR also bumps the package version to 0.2.4