### PR TITLE
fix: cast UUID variables to UUID before comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Cast variables to UUID before comparison to UUID columns. This enables remote relationships to UUID columns
+
 ## [0.2.4]
 
 - Allow explain of invalid foreach queries. Will generate invalid SQL, for proper execution these should be parameterized


### PR DESCRIPTION
https://hasurahq.atlassian.net/browse/CLIK-15

When referencing a variable in the _vars table for comparison,
check if the column being compared against is a (nullable?) UUID,
and if so cast the variable value to UUID using `toUUID`

Also do the same when passing a variable to a parameterized query that has a UUID parameter.