### PR TITLE
Fix capabilities version, upgrade SDK to v0.1.4, fix Clippy lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,12 +221,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -1097,8 +1091,8 @@ dependencies = [
 
 [[package]]
 name = "ndc-models"
-version = "0.1.2"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.2#6e7d12a31787d5f618099a42ddc0bea786438c00"
+version = "0.1.4"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.4#20172e3b2552b78d16dbafcd047f559ced420309"
 dependencies = [
  "indexmap 2.2.5",
  "schemars",
@@ -1109,8 +1103,8 @@ dependencies = [
 
 [[package]]
 name = "ndc-sdk"
-version = "0.1.0"
-source = "git+https://github.com/hasura/ndc-sdk-rs?rev=972dba6#972dba6e270ad54f4748487f75018c24229c1e5e"
+version = "0.1.4"
+source = "git+https://github.com/hasura/ndc-sdk-rs?tag=v0.1.4#29adcb5983c1237e8a5f4732d5230c2ba8ab75d3"
 dependencies = [
  "async-trait",
  "axum",
@@ -1142,8 +1136,8 @@ dependencies = [
 
 [[package]]
 name = "ndc-test"
-version = "0.1.2"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.2#6e7d12a31787d5f618099a42ddc0bea786438c00"
+version = "0.1.4"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.4#20172e3b2552b78d16dbafcd047f559ced420309"
 dependencies = [
  "async-trait",
  "clap",
@@ -1969,15 +1963,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.3.3"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
+checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.0",
  "chrono",
  "hex",
  "indexmap 1.9.3",
+ "indexmap 2.2.5",
  "serde",
+ "serde_derive",
  "serde_json",
  "serde_with_macros",
  "time",
@@ -1985,9 +1981,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "2.3.3"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
+checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/crates/common/src/clickhouse_parser.rs
+++ b/crates/common/src/clickhouse_parser.rs
@@ -226,7 +226,7 @@ fn can_parse_parameterized_query() {
             }),
         ],
     };
-    let parsed = clickhouse_parser::parameterized_query(&query);
+    let parsed = clickhouse_parser::parameterized_query(query);
     assert_eq!(parsed, Ok(expected), "can parse parameterized query");
 }
 
@@ -234,7 +234,7 @@ fn can_parse_parameterized_query() {
 fn can_parse_empty_parameterized_query() {
     let query = r#""#;
     let expected = ParameterizedQuery { elements: vec![] };
-    let parsed = clickhouse_parser::parameterized_query(&query);
+    let parsed = clickhouse_parser::parameterized_query(query);
     assert_eq!(parsed, Ok(expected), "can parse parameterized query");
 }
 
@@ -259,6 +259,6 @@ fn does_not_parse_parameters_insides_quoted_strings() {
             ParameterizedQueryElement::String(" AND Name = '{ArtistName: String}'".to_string()),
         ],
     };
-    let parsed = clickhouse_parser::parameterized_query(&query);
+    let parsed = clickhouse_parser::parameterized_query(query);
     assert_eq!(parsed, Ok(expected), "can parse parameterized query");
 }

--- a/crates/ndc-clickhouse-cli/src/main.rs
+++ b/crates/ndc-clickhouse-cli/src/main.rs
@@ -157,7 +157,7 @@ async fn read_config_file(file_path: &PathBuf) -> Result<Option<ServerConfigFile
 
 async fn update_tables_config(
     configuration_dir: impl AsRef<Path> + Send,
-    introspection: &Vec<TableInfo>,
+    introspection: &[TableInfo],
 ) -> Result<ServerConfigFile, Box<dyn Error>> {
     let file_path = configuration_dir.as_ref().join(CONFIG_FILE_NAME);
     let schema_file_path = configuration_dir.as_ref().join(CONFIG_SCHEMA_FILE_NAME);
@@ -206,7 +206,7 @@ async fn update_tables_config(
                     table,
                     &old_table_config,
                     &old_config,
-                    &introspection,
+                    introspection,
                 ),
             };
 
@@ -216,7 +216,7 @@ async fn update_tables_config(
 
     let config = ServerConfigFile {
         schema: CONFIG_SCHEMA_FILE_NAME.to_owned(),
-        tables: tables,
+        tables,
         queries: old_config
             .as_ref()
             .map(|old_config| old_config.queries.to_owned())
@@ -295,7 +295,7 @@ async fn validate_table_config(
             ReturnType::Definition { columns } => {
                 for (column_alias, column_data_type) in columns {
                     let _data_type =
-                        ClickHouseDataType::from_str(&column_data_type).map_err(|err| {
+                        ClickHouseDataType::from_str(column_data_type).map_err(|err| {
                             format!(
                                 "Unable to parse data type \"{}\" for column {} in table {}: {}",
                                 column_data_type, column_alias, table_alias, err
@@ -368,7 +368,7 @@ async fn validate_table_config(
             ReturnType::Definition { columns } => {
                 for (column_name, column_data_type) in columns {
                     let _data_type =
-                        ClickHouseDataType::from_str(&column_data_type).map_err(|err| {
+                        ClickHouseDataType::from_str(column_data_type).map_err(|err| {
                             format!(
                                 "Unable to parse data type \"{}\" for field {} in query {}: {}",
                                 column_data_type, column_name, query_alias, err
@@ -435,7 +435,7 @@ fn get_table_return_type(
     table: &TableInfo,
     old_table: &Option<(&String, &TableConfigFile)>,
     old_config: &Option<ServerConfigFile>,
-    introspection: &Vec<TableInfo>,
+    introspection: &[TableInfo],
 ) -> ReturnType {
     let new_columns = get_return_type_columns(table);
 
@@ -495,7 +495,7 @@ fn get_table_return_type(
             },
         );
 
-    old_return_type.unwrap_or_else(|| ReturnType::Definition {
+    old_return_type.unwrap_or(ReturnType::Definition {
         columns: new_columns,
     })
 }

--- a/crates/ndc-clickhouse/Cargo.toml
+++ b/crates/ndc-clickhouse/Cargo.toml
@@ -8,7 +8,7 @@ async-trait = "0.1.78"
 bytes = "1.6.0"
 common = { path = "../common" }
 indexmap = "2.1.0"
-ndc-sdk = { git = "https://github.com/hasura/ndc-sdk-rs", rev = "972dba6", package = "ndc-sdk" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-sdk-rs", tag = "v0.1.4", package = "ndc-sdk" }
 prometheus = "0.13.3"
 reqwest = { version = "0.12.3", features = [
   "json",

--- a/crates/ndc-clickhouse/src/connector.rs
+++ b/crates/ndc-clickhouse/src/connector.rs
@@ -1,12 +1,7 @@
 pub mod handler;
 pub mod state;
 
-use std::{
-    collections::BTreeMap,
-    env,
-    path::Path,
-    str::FromStr,
-};
+use std::{collections::BTreeMap, env, path::Path, str::FromStr};
 use tokio::fs;
 
 use async_trait::async_trait;

--- a/crates/ndc-clickhouse/src/connector/handler/capabilities.rs
+++ b/crates/ndc-clickhouse/src/connector/handler/capabilities.rs
@@ -1,13 +1,18 @@
-use ndc_sdk::models::{self, LeafCapability, RelationshipCapabilities};
+use ndc_sdk::models::{self, LeafCapability, NestedFieldCapabilities, RelationshipCapabilities};
 
 pub fn capabilities() -> models::CapabilitiesResponse {
     models::CapabilitiesResponse {
-        version: "^0.1.1".to_string(),
+        version: "0.1.4".to_owned(),
         capabilities: models::Capabilities {
             query: models::QueryCapabilities {
                 aggregates: Some(LeafCapability {}),
                 variables: Some(LeafCapability {}),
                 explain: Some(LeafCapability {}),
+                nested_fields: NestedFieldCapabilities {
+                    filter_by: None,
+                    order_by: None,
+                    aggregates: None,
+                },
             },
             mutation: models::MutationCapabilities {
                 transactional: None,

--- a/crates/ndc-clickhouse/src/connector/handler/query.rs
+++ b/crates/ndc-clickhouse/src/connector/handler/query.rs
@@ -60,7 +60,7 @@ pub async fn query(
     )
     .instrument(execution_span)
     .await
-    .map_err(|err| QueryError::UnprocessableContent(err.to_string().into()))?;
+    .map_err(|err| QueryError::UnprocessableContent(err.to_string()))?;
 
     #[cfg(debug_assertions)]
     {

--- a/crates/ndc-clickhouse/src/connector/handler/schema.rs
+++ b/crates/ndc-clickhouse/src/connector/handler/schema.rs
@@ -1,4 +1,4 @@
-use crate::schema::ClickHouseTypeDefinition;
+use crate::schema::{ClickHouseTypeDefinition, SchemaTypeDefinitions};
 use common::{
     clickhouse_parser::{
         datatype::ClickHouseDataType,
@@ -20,13 +20,13 @@ pub async fn schema(
         let mut fields = vec![];
         for (column_alias, column_type) in &table_type.columns {
             let type_definition = ClickHouseTypeDefinition::from_table_column(
-                &column_type,
-                &column_alias,
-                &type_name,
+                column_type,
+                column_alias,
+                type_name,
                 &configuration.namespace_separator,
             );
 
-            let (scalars, objects) = type_definition.type_definitions();
+            let SchemaTypeDefinitions { scalars, objects } = type_definition.type_definitions();
 
             for (name, definition) in objects {
                 object_type_definitions.push((name, definition));
@@ -60,12 +60,12 @@ pub async fn schema(
     for (table_alias, table_config) in &configuration.tables {
         for (argument_name, argument_type) in &table_config.arguments {
             let type_definition = ClickHouseTypeDefinition::from_query_argument(
-                &argument_type,
-                &argument_name,
+                argument_type,
+                argument_name,
                 table_alias,
                 &configuration.namespace_separator,
             );
-            let (scalars, objects) = type_definition.type_definitions();
+            let SchemaTypeDefinitions { scalars, objects } = type_definition.type_definitions();
 
             for (name, definition) in objects {
                 object_type_definitions.push((name, definition));
@@ -93,7 +93,7 @@ pub async fn schema(
                     &configuration.namespace_separator,
                 );
 
-                let (scalars, objects) = type_definition.type_definitions();
+                let SchemaTypeDefinitions { scalars, objects } = type_definition.type_definitions();
 
                 for (name, definition) in objects {
                     object_type_definitions.push((name, definition));
@@ -119,8 +119,8 @@ pub async fn schema(
                 .iter()
                 .map(|(argument_name, argument_type)| {
                     let type_definition = ClickHouseTypeDefinition::from_query_argument(
-                        &argument_type,
-                        &argument_name,
+                        argument_type,
+                        argument_name,
                         table_alias,
                         &configuration.namespace_separator,
                     );
@@ -166,7 +166,7 @@ pub async fn schema(
                     ParameterizedQueryElement::Parameter(Parameter { name, r#type }) => {
                         let data_type = match r#type {
                             ParameterType::Identifier => &ClickHouseDataType::String,
-                            ParameterType::DataType(t) => &t,
+                            ParameterType::DataType(t) => t,
                         };
                         let type_definition = ClickHouseTypeDefinition::from_query_argument(
                             data_type,

--- a/crates/ndc-clickhouse/src/connector/handler/schema.rs
+++ b/crates/ndc-clickhouse/src/connector/handler/schema.rs
@@ -43,6 +43,7 @@ pub async fn schema(
                 models::ObjectField {
                     description: None,
                     r#type: type_definition.type_identifier(),
+                    arguments: BTreeMap::new(),
                 },
             ));
         }

--- a/crates/ndc-clickhouse/src/sql/query_builder.rs
+++ b/crates/ndc-clickhouse/src/sql/query_builder.rs
@@ -218,6 +218,7 @@ impl<'r, 'c> QueryBuilder<'r, 'c> {
                             models::Aggregate::ColumnCount {
                                 distinct,
                                 column: _,
+                                field_path: _,
                             } => {
                                 let column = Expr::CompoundIdentifier(vec![
                                     Ident::new_quoted("_row"),
@@ -231,6 +232,7 @@ impl<'r, 'c> QueryBuilder<'r, 'c> {
                             models::Aggregate::SingleColumn {
                                 function,
                                 column: _,
+                                field_path: _,
                             } => {
                                 let column = Expr::CompoundIdentifier(vec![
                                     Ident::new_quoted("_row"),
@@ -318,7 +320,11 @@ impl<'r, 'c> QueryBuilder<'r, 'c> {
             let mut rel_index = 0;
             for (alias, field) in fields {
                 match field {
-                    models::Field::Column { column, fields } => {
+                    models::Field::Column {
+                        column,
+                        fields,
+                        arguments: _,
+                    } => {
                         let data_type = self.column_data_type(column, current_collection)?;
                         let column_definition = ClickHouseTypeDefinition::from_table_column(
                             &data_type,
@@ -492,7 +498,11 @@ impl<'r, 'c> QueryBuilder<'r, 'c> {
 
             for element in &order_by.elements {
                 match &element.target {
-                    models::OrderByTarget::Column { name, path } if path.is_empty() => {
+                    models::OrderByTarget::Column {
+                        name,
+                        path,
+                        field_path: _,
+                    } if path.is_empty() => {
                         let expr = Expr::CompoundIdentifier(vec![
                             Ident::new_quoted("_origin"),
                             self.column_ident(name),
@@ -698,7 +708,11 @@ impl<'r, 'c> QueryBuilder<'r, 'c> {
                             }
 
                             match &element.target {
-                                models::OrderByTarget::Column { name, path: _ } => {
+                                models::OrderByTarget::Column {
+                                    name,
+                                    path: _,
+                                    field_path: _,
+                                } => {
                                     let column = Expr::CompoundIdentifier(vec![
                                         last_join_alias,
                                         self.column_ident(name),
@@ -710,6 +724,7 @@ impl<'r, 'c> QueryBuilder<'r, 'c> {
                                     column,
                                     function,
                                     path: _,
+                                    field_path: _,
                                 } => {
                                     let column = Expr::CompoundIdentifier(vec![
                                         last_join_alias,
@@ -1286,6 +1301,7 @@ impl<'r, 'c> QueryBuilder<'r, 'c> {
             models::ComparisonTarget::Column {
                 name: comparison_column_name,
                 path,
+                field_path: _,
             } => {
                 if let Some(first_element) = path.first() {
                     if current_is_origin {
@@ -1649,7 +1665,10 @@ impl<'r, 'c> QueryBuilder<'r, 'c> {
                     ))
                 }
             }
-            models::ComparisonTarget::RootCollectionColumn { name } => {
+            models::ComparisonTarget::RootCollectionColumn {
+                name,
+                field_path: _,
+            } => {
                 if current_is_origin {
                     let column_ident = Expr::CompoundIdentifier(vec![
                         current_join_alias.clone(),
@@ -1964,7 +1983,11 @@ impl<'r, 'c> QueryBuilder<'r, 'c> {
                     let mut accessor_required = false;
                     for (alias, field) in &inner.fields {
                         match field {
-                            models::Field::Column { column, fields } => {
+                            models::Field::Column {
+                                column,
+                                fields,
+                                arguments: _,
+                            } => {
                                 required_columns.push(column);
 
                                 let type_definition =

--- a/crates/ndc-clickhouse/src/sql/query_builder.rs
+++ b/crates/ndc-clickhouse/src/sql/query_builder.rs
@@ -849,8 +849,7 @@ impl<'r, 'c> QueryBuilder<'r, 'c> {
         *name_index += 1;
 
         let relationship = self.collection_relationship(relationship)?;
-        let relationship_collection =
-            CollectionContext::from_relationship(relationship, arguments);
+        let relationship_collection = CollectionContext::from_relationship(relationship, arguments);
 
         let mut join_expr = relationship
             .column_mapping

--- a/crates/ndc-clickhouse/src/sql/query_builder/collection_context.rs
+++ b/crates/ndc-clickhouse/src/sql/query_builder/collection_context.rs
@@ -55,7 +55,7 @@ impl<'a, 'b> CollectionContext<'a, 'b> {
             }
             | CollectionContext::UnrelatedRelationship {
                 collection_alias, ..
-            } => &collection_alias,
+            } => collection_alias,
         }
     }
     pub fn has_arguments(&self) -> bool {

--- a/crates/ndc-clickhouse/src/sql/query_builder/typecasting.rs
+++ b/crates/ndc-clickhouse/src/sql/query_builder/typecasting.rs
@@ -104,14 +104,14 @@ impl AggregatesTypeString {
                     } => {
                         let column_type = get_column(column_alias, table_alias, config)?;
                         let type_definition = ClickHouseTypeDefinition::from_table_column(
-                            &column_type,
+                            column_type,
                             column_alias,
                             table_alias,
                             &config.namespace_separator,
                         );
 
                         let aggregate_function =
-                            ClickHouseSingleColumnAggregateFunction::from_str(&function).map_err(
+                            ClickHouseSingleColumnAggregateFunction::from_str(function).map_err(
                                 |_err| TypeStringError::UnknownAggregateFunction {
                                     table: table_alias.to_owned(),
                                     column: column_alias.to_owned(),
@@ -177,7 +177,7 @@ impl RowTypeString {
                             } => {
                                 let column_type = get_column(column_alias, table_alias, config)?;
                                 let type_definition = ClickHouseTypeDefinition::from_table_column(
-                                    &column_type,
+                                    column_type,
                                     column_alias,
                                     table_alias,
                                     &config.namespace_separator,
@@ -282,7 +282,7 @@ impl FieldTypeString {
                                     Ok((
                                         alias.to_owned(),
                                         FieldTypeString::new(
-                                            &type_definition,
+                                            type_definition,
                                             subfield_selector.as_ref(),
                                             relationships,
                                             config,

--- a/crates/ndc-clickhouse/src/sql/query_builder/typecasting.rs
+++ b/crates/ndc-clickhouse/src/sql/query_builder/typecasting.rs
@@ -100,6 +100,7 @@ impl AggregatesTypeString {
                     models::Aggregate::SingleColumn {
                         column: column_alias,
                         function,
+                        field_path: _,
                     } => {
                         let column_type = get_column(column_alias, table_alias, config)?;
                         let type_definition = ClickHouseTypeDefinition::from_table_column(
@@ -172,6 +173,7 @@ impl RowTypeString {
                             models::Field::Column {
                                 column: column_alias,
                                 fields,
+                                arguments: _,
                             } => {
                                 let column_type = get_column(column_alias, table_alias, config)?;
                                 let type_definition = ClickHouseTypeDefinition::from_table_column(
@@ -268,6 +270,7 @@ impl FieldTypeString {
                                 models::Field::Column {
                                     column,
                                     fields: subfield_selector,
+                                    arguments: _,
                                 } => {
                                     let type_definition = fields.get(column).ok_or_else(|| {
                                         TypeStringError::MissingNestedField {

--- a/crates/ndc-clickhouse/tests/query_builder.rs
+++ b/crates/ndc-clickhouse/tests/query_builder.rs
@@ -72,7 +72,7 @@ mod test_utils {
     ) -> Result<(), Box<dyn Error>> {
         let statement_path =
             tests_dir_path(schema_dir, group_dir).join(format!("{test_name}.statement.sql"));
-        let pretty_statement = pretty_print_sql(&generated_statement);
+        let pretty_statement = pretty_print_sql(generated_statement);
         fs::write(&statement_path, &pretty_statement).await?;
         Ok(())
     }
@@ -92,7 +92,7 @@ mod test_utils {
         request: &models::QueryRequest,
     ) -> Result<String, QueryBuilderError> {
         let generated_statement = pretty_print_sql(
-            &QueryBuilder::new(&request, &configuration)
+            &QueryBuilder::new(request, configuration)
                 .build()?
                 .to_unsafe_sql_string(),
         );


### PR DESCRIPTION
This PR fixes a fairly significant bug in the capabilities response, where the connector returns an invalid version. It returns a semver range, rather than just a semantic version, which is against the spec. It's probably a holdover from an old version of the spec that never got changed. 

This has caused issues now that engine actually looks at the value in that property.

The PR also updates the NDC Rust SDK to the latest easily updatable version (v0.1.4). A more recent version brings in new newtypes that I'm not prepared to deal with for this small fix.

The PR also fixes all the various clippy lint warnings across the code (in separate commit for easier reviewing).