### PR TITLE
Add aliasing to create named tuples

### DIFF
--- a/crates/ndc-clickhouse/src/sql/ast.rs
+++ b/crates/ndc-clickhouse/src/sql/ast.rs
@@ -685,11 +685,16 @@ impl fmt::Display for WindowSpec {
 pub struct FunctionArg {
     name: Option<Ident>,
     value: FunctionArgExpr,
+    alias: Option<Ident>,
 }
 
 impl FunctionArg {
     pub fn new(value: FunctionArgExpr) -> Self {
-        Self { value, name: None }
+        Self {
+            value,
+            name: None,
+            alias: None,
+        }
     }
     pub fn name(self, name: Ident) -> Self {
         Self {
@@ -697,14 +702,24 @@ impl FunctionArg {
             ..self
         }
     }
+    pub fn with_alias(self, alias: Ident) -> Self {
+        Self {
+            alias: Some(alias),
+            ..self
+        }
+    }
 }
 
 impl fmt::Display for FunctionArg {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.name {
-            Some(name) => write!(f, "{name}={}", self.value),
-            None => write!(f, "{}", self.value),
+        if let Some(name) = &self.name {
+            write!(f, "{name}=")?;
         }
+        write!(f, "{}", self.value)?;
+        if let Some(alias) = &self.alias {
+            write!(f, " AS {alias}")?;
+        }
+        Ok(())
     }
 }
 

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@01_simple_queries_01_select_rows.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@01_simple_queries_01_select_rows.request.json.snap
@@ -18,11 +18,11 @@ FROM
       tuple(
         groupArray(
           tuple(
-            "_row"."_field_albumId",
-            "_row"."_field_artistId",
-            "_row"."_field_title"
+            "_row"."_field_albumId" AS "albumId",
+            "_row"."_field_artistId" AS "artistId",
+            "_row"."_field_title" AS "title"
           )
-        )
+        ) AS "rows"
       ) AS "_rowset"
     FROM
       (

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@01_simple_queries_02_with_predicate.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@01_simple_queries_02_with_predicate.request.json.snap
@@ -18,11 +18,11 @@ FROM
       tuple(
         groupArray(
           tuple(
-            "_row"."_field_albumId",
-            "_row"."_field_artistId",
-            "_row"."_field_title"
+            "_row"."_field_albumId" AS "albumId",
+            "_row"."_field_artistId" AS "artistId",
+            "_row"."_field_title" AS "title"
           )
-        )
+        ) AS "rows"
       ) AS "_rowset"
     FROM
       (

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@01_simple_queries_03_larger_predicate.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@01_simple_queries_03_larger_predicate.request.json.snap
@@ -18,11 +18,11 @@ FROM
       tuple(
         groupArray(
           tuple(
-            "_row"."_field_albumId",
-            "_row"."_field_artistId",
-            "_row"."_field_title"
+            "_row"."_field_albumId" AS "albumId",
+            "_row"."_field_artistId" AS "artistId",
+            "_row"."_field_title" AS "title"
           )
-        )
+        ) AS "rows"
       ) AS "_rowset"
     FROM
       (

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@01_simple_queries_04_limit.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@01_simple_queries_04_limit.request.json.snap
@@ -18,11 +18,11 @@ FROM
       tuple(
         groupArray(
           tuple(
-            "_row"."_field_albumId",
-            "_row"."_field_artistId",
-            "_row"."_field_title"
+            "_row"."_field_albumId" AS "albumId",
+            "_row"."_field_artistId" AS "artistId",
+            "_row"."_field_title" AS "title"
           )
-        )
+        ) AS "rows"
       ) AS "_rowset"
     FROM
       (

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@01_simple_queries_05_offset.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@01_simple_queries_05_offset.request.json.snap
@@ -18,11 +18,11 @@ FROM
       tuple(
         groupArray(
           tuple(
-            "_row"."_field_albumId",
-            "_row"."_field_artistId",
-            "_row"."_field_title"
+            "_row"."_field_albumId" AS "albumId",
+            "_row"."_field_artistId" AS "artistId",
+            "_row"."_field_title" AS "title"
           )
-        )
+        ) AS "rows"
       ) AS "_rowset"
     FROM
       (

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@01_simple_queries_06_limit_offset.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@01_simple_queries_06_limit_offset.request.json.snap
@@ -18,11 +18,11 @@ FROM
       tuple(
         groupArray(
           tuple(
-            "_row"."_field_albumId",
-            "_row"."_field_artistId",
-            "_row"."_field_title"
+            "_row"."_field_albumId" AS "albumId",
+            "_row"."_field_artistId" AS "artistId",
+            "_row"."_field_title" AS "title"
           )
-        )
+        ) AS "rows"
       ) AS "_rowset"
     FROM
       (

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@01_simple_queries_07_order_by.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@01_simple_queries_07_order_by.request.json.snap
@@ -18,11 +18,11 @@ FROM
       tuple(
         groupArray(
           tuple(
-            "_row"."_field_albumId",
-            "_row"."_field_artistId",
-            "_row"."_field_title"
+            "_row"."_field_albumId" AS "albumId",
+            "_row"."_field_artistId" AS "artistId",
+            "_row"."_field_title" AS "title"
           )
-        )
+        ) AS "rows"
       ) AS "_rowset"
     FROM
       (

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@01_simple_queries_08_predicate_limit_offset_order_by.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@01_simple_queries_08_predicate_limit_offset_order_by.request.json.snap
@@ -18,11 +18,11 @@ FROM
       tuple(
         groupArray(
           tuple(
-            "_row"."_field_albumId",
-            "_row"."_field_artistId",
-            "_row"."_field_title"
+            "_row"."_field_albumId" AS "albumId",
+            "_row"."_field_artistId" AS "artistId",
+            "_row"."_field_title" AS "title"
           )
-        )
+        ) AS "rows"
       ) AS "_rowset"
     FROM
       (

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@02_relationships_01_object_relationship.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@02_relationships_01_object_relationship.request.json.snap
@@ -18,12 +18,12 @@ FROM
       tuple(
         groupArray(
           tuple(
-            "_row"."_field_albumId",
-            "_row"."_field_artistId",
-            "_row"."_field_title",
-            "_row"."_field_Artist"
+            "_row"."_field_albumId" AS "albumId",
+            "_row"."_field_artistId" AS "artistId",
+            "_row"."_field_title" AS "title",
+            "_row"."_field_Artist" AS "Artist"
           )
-        )
+        ) AS "rows"
       ) AS "_rowset"
     FROM
       (
@@ -38,8 +38,11 @@ FROM
             SELECT
               tuple(
                 groupArray(
-                  tuple("_row"."_field_artistId", "_row"."_field_name")
-                )
+                  tuple(
+                    "_row"."_field_artistId" AS "artistId",
+                    "_row"."_field_name" AS "name"
+                  )
+                ) AS "rows"
               ) AS "_rowset",
               "_row"."_relkey_ArtistId" AS "_relkey_ArtistId"
             FROM

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@02_relationships_02_array_relationship.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@02_relationships_02_array_relationship.request.json.snap
@@ -18,12 +18,12 @@ FROM
       tuple(
         groupArray(
           tuple(
-            "_row"."_field_albumId",
-            "_row"."_field_artistId",
-            "_row"."_field_title",
-            "_row"."_field_Tracks"
+            "_row"."_field_albumId" AS "albumId",
+            "_row"."_field_artistId" AS "artistId",
+            "_row"."_field_title" AS "title",
+            "_row"."_field_Tracks" AS "Tracks"
           )
-        )
+        ) AS "rows"
       ) AS "_rowset"
     FROM
       (
@@ -39,11 +39,11 @@ FROM
               tuple(
                 groupArray(
                   tuple(
-                    "_row"."_field_trackId",
-                    "_row"."_field_name",
-                    "_row"."_field_unitPrice"
+                    "_row"."_field_trackId" AS "trackId",
+                    "_row"."_field_name" AS "name",
+                    "_row"."_field_unitPrice" AS "unitPrice"
                   )
-                )
+                ) AS "rows"
               ) AS "_rowset",
               "_row"."_relkey_AlbumId" AS "_relkey_AlbumId"
             FROM

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@02_relationships_03_parent_predicate.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@02_relationships_03_parent_predicate.request.json.snap
@@ -18,12 +18,12 @@ FROM
       tuple(
         groupArray(
           tuple(
-            "_row"."_field_albumId",
-            "_row"."_field_artistId",
-            "_row"."_field_title",
-            "_row"."_field_Tracks"
+            "_row"."_field_albumId" AS "albumId",
+            "_row"."_field_artistId" AS "artistId",
+            "_row"."_field_title" AS "title",
+            "_row"."_field_Tracks" AS "Tracks"
           )
-        )
+        ) AS "rows"
       ) AS "_rowset"
     FROM
       (
@@ -39,11 +39,11 @@ FROM
               tuple(
                 groupArray(
                   tuple(
-                    "_row"."_field_trackId",
-                    "_row"."_field_name",
-                    "_row"."_field_unitPrice"
+                    "_row"."_field_trackId" AS "trackId",
+                    "_row"."_field_name" AS "name",
+                    "_row"."_field_unitPrice" AS "unitPrice"
                   )
-                )
+                ) AS "rows"
               ) AS "_rowset",
               "_row"."_relkey_AlbumId" AS "_relkey_AlbumId"
             FROM

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@02_relationships_04_child_predicate.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@02_relationships_04_child_predicate.request.json.snap
@@ -18,12 +18,12 @@ FROM
       tuple(
         groupArray(
           tuple(
-            "_row"."_field_albumId",
-            "_row"."_field_artistId",
-            "_row"."_field_title",
-            "_row"."_field_Tracks"
+            "_row"."_field_albumId" AS "albumId",
+            "_row"."_field_artistId" AS "artistId",
+            "_row"."_field_title" AS "title",
+            "_row"."_field_Tracks" AS "Tracks"
           )
-        )
+        ) AS "rows"
       ) AS "_rowset"
     FROM
       (
@@ -39,11 +39,11 @@ FROM
               tuple(
                 groupArray(
                   tuple(
-                    "_row"."_field_trackId",
-                    "_row"."_field_name",
-                    "_row"."_field_unitPrice"
+                    "_row"."_field_trackId" AS "trackId",
+                    "_row"."_field_name" AS "name",
+                    "_row"."_field_unitPrice" AS "unitPrice"
                   )
-                )
+                ) AS "rows"
               ) AS "_rowset",
               "_row"."_relkey_AlbumId" AS "_relkey_AlbumId"
             FROM

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@02_relationships_05_traverse_relationship_in_predicate.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@02_relationships_05_traverse_relationship_in_predicate.request.json.snap
@@ -18,12 +18,12 @@ FROM
       tuple(
         groupArray(
           tuple(
-            "_row"."_field_albumId",
-            "_row"."_field_artistId",
-            "_row"."_field_title",
-            "_row"."_field_Tracks"
+            "_row"."_field_albumId" AS "albumId",
+            "_row"."_field_artistId" AS "artistId",
+            "_row"."_field_title" AS "title",
+            "_row"."_field_Tracks" AS "Tracks"
           )
-        )
+        ) AS "rows"
       ) AS "_rowset"
     FROM
       (
@@ -39,11 +39,11 @@ FROM
               tuple(
                 groupArray(
                   tuple(
-                    "_row"."_field_trackId",
-                    "_row"."_field_name",
-                    "_row"."_field_unitPrice"
+                    "_row"."_field_trackId" AS "trackId",
+                    "_row"."_field_name" AS "name",
+                    "_row"."_field_unitPrice" AS "unitPrice"
                   )
-                )
+                ) AS "rows"
               ) AS "_rowset",
               "_row"."_relkey_AlbumId" AS "_relkey_AlbumId"
             FROM

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@02_relationships_06_traverse_relationship_in_order_by.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@02_relationships_06_traverse_relationship_in_order_by.request.json.snap
@@ -18,11 +18,11 @@ FROM
       tuple(
         groupArray(
           tuple(
-            "_row"."_field_trackId",
-            "_row"."_field_name",
-            "_row"."_field_Album"
+            "_row"."_field_trackId" AS "trackId",
+            "_row"."_field_name" AS "name",
+            "_row"."_field_Album" AS "Album"
           )
-        )
+        ) AS "rows"
       ) AS "_rowset"
     FROM
       (
@@ -34,7 +34,9 @@ FROM
           "Chinook"."Track" AS "_origin"
           LEFT JOIN (
             SELECT
-              tuple(groupArray(tuple("_row"."_field_Artist"))) AS "_rowset",
+              tuple(
+                groupArray(tuple("_row"."_field_Artist" AS "Artist")) AS "rows"
+              ) AS "_rowset",
               "_row"."_relkey_AlbumId" AS "_relkey_AlbumId"
             FROM
               (
@@ -45,7 +47,9 @@ FROM
                   "Chinook"."Album" AS "_origin"
                   LEFT JOIN (
                     SELECT
-                      tuple(groupArray(tuple("_row"."_field_name"))) AS "_rowset",
+                      tuple(
+                        groupArray(tuple("_row"."_field_name" AS "name")) AS "rows"
+                      ) AS "_rowset",
                       "_row"."_relkey_ArtistId" AS "_relkey_ArtistId"
                     FROM
                       (

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@02_relationships_07_order_by_aggregate_across_relationships.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@02_relationships_07_order_by_aggregate_across_relationships.request.json.snap
@@ -17,8 +17,11 @@ FROM
     SELECT
       tuple(
         groupArray(
-          tuple("_row"."_field_trackId", "_row"."_field_name")
-        )
+          tuple(
+            "_row"."_field_trackId" AS "trackId",
+            "_row"."_field_name" AS "name"
+          )
+        ) AS "rows"
       ) AS "_rowset"
     FROM
       (

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@03_variables_01_simple_predicate.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@03_variables_01_simple_predicate.request.json.snap
@@ -28,11 +28,11 @@ FROM
       tuple(
         groupArray(
           tuple(
-            "_row"."_field_albumId",
-            "_row"."_field_artistId",
-            "_row"."_field_title"
+            "_row"."_field_albumId" AS "albumId",
+            "_row"."_field_artistId" AS "artistId",
+            "_row"."_field_title" AS "title"
           )
-        )
+        ) AS "rows"
       ) AS "_rowset",
       "_row"."_varset_id" AS "_varset_id"
     FROM

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@03_variables_02_empty_variable_sets.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@03_variables_02_empty_variable_sets.request.json.snap
@@ -25,11 +25,11 @@ FROM
       tuple(
         groupArray(
           tuple(
-            "_row"."_field_albumId",
-            "_row"."_field_artistId",
-            "_row"."_field_title"
+            "_row"."_field_albumId" AS "albumId",
+            "_row"."_field_artistId" AS "artistId",
+            "_row"."_field_title" AS "title"
           )
-        )
+        ) AS "rows"
       ) AS "_rowset",
       "_row"."_varset_id" AS "_varset_id"
     FROM

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@03_variables_03_single_set.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Inlined SQL@03_variables_03_single_set.request.json.snap
@@ -28,11 +28,11 @@ FROM
       tuple(
         groupArray(
           tuple(
-            "_row"."_field_albumId",
-            "_row"."_field_artistId",
-            "_row"."_field_title"
+            "_row"."_field_albumId" AS "albumId",
+            "_row"."_field_artistId" AS "artistId",
+            "_row"."_field_title" AS "title"
           )
-        )
+        ) AS "rows"
       ) AS "_rowset",
       "_row"."_varset_id" AS "_varset_id"
     FROM

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Parameterized SQL@01_simple_queries_02_with_predicate.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Parameterized SQL@01_simple_queries_02_with_predicate.request.json.snap
@@ -18,11 +18,11 @@ FROM
       tuple(
         groupArray(
           tuple(
-            "_row"."_field_albumId",
-            "_row"."_field_artistId",
-            "_row"."_field_title"
+            "_row"."_field_albumId" AS "albumId",
+            "_row"."_field_artistId" AS "artistId",
+            "_row"."_field_title" AS "title"
           )
-        )
+        ) AS "rows"
       ) AS "_rowset"
     FROM
       (

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Parameterized SQL@01_simple_queries_03_larger_predicate.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Parameterized SQL@01_simple_queries_03_larger_predicate.request.json.snap
@@ -18,11 +18,11 @@ FROM
       tuple(
         groupArray(
           tuple(
-            "_row"."_field_albumId",
-            "_row"."_field_artistId",
-            "_row"."_field_title"
+            "_row"."_field_albumId" AS "albumId",
+            "_row"."_field_artistId" AS "artistId",
+            "_row"."_field_title" AS "title"
           )
-        )
+        ) AS "rows"
       ) AS "_rowset"
     FROM
       (

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Parameterized SQL@01_simple_queries_08_predicate_limit_offset_order_by.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Parameterized SQL@01_simple_queries_08_predicate_limit_offset_order_by.request.json.snap
@@ -18,11 +18,11 @@ FROM
       tuple(
         groupArray(
           tuple(
-            "_row"."_field_albumId",
-            "_row"."_field_artistId",
-            "_row"."_field_title"
+            "_row"."_field_albumId" AS "albumId",
+            "_row"."_field_artistId" AS "artistId",
+            "_row"."_field_title" AS "title"
           )
-        )
+        ) AS "rows"
       ) AS "_rowset"
     FROM
       (

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Parameterized SQL@02_relationships_03_parent_predicate.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Parameterized SQL@02_relationships_03_parent_predicate.request.json.snap
@@ -18,12 +18,12 @@ FROM
       tuple(
         groupArray(
           tuple(
-            "_row"."_field_albumId",
-            "_row"."_field_artistId",
-            "_row"."_field_title",
-            "_row"."_field_Tracks"
+            "_row"."_field_albumId" AS "albumId",
+            "_row"."_field_artistId" AS "artistId",
+            "_row"."_field_title" AS "title",
+            "_row"."_field_Tracks" AS "Tracks"
           )
-        )
+        ) AS "rows"
       ) AS "_rowset"
     FROM
       (
@@ -39,11 +39,11 @@ FROM
               tuple(
                 groupArray(
                   tuple(
-                    "_row"."_field_trackId",
-                    "_row"."_field_name",
-                    "_row"."_field_unitPrice"
+                    "_row"."_field_trackId" AS "trackId",
+                    "_row"."_field_name" AS "name",
+                    "_row"."_field_unitPrice" AS "unitPrice"
                   )
-                )
+                ) AS "rows"
               ) AS "_rowset",
               "_row"."_relkey_AlbumId" AS "_relkey_AlbumId"
             FROM

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Parameterized SQL@02_relationships_04_child_predicate.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Parameterized SQL@02_relationships_04_child_predicate.request.json.snap
@@ -18,12 +18,12 @@ FROM
       tuple(
         groupArray(
           tuple(
-            "_row"."_field_albumId",
-            "_row"."_field_artistId",
-            "_row"."_field_title",
-            "_row"."_field_Tracks"
+            "_row"."_field_albumId" AS "albumId",
+            "_row"."_field_artistId" AS "artistId",
+            "_row"."_field_title" AS "title",
+            "_row"."_field_Tracks" AS "Tracks"
           )
-        )
+        ) AS "rows"
       ) AS "_rowset"
     FROM
       (
@@ -39,11 +39,11 @@ FROM
               tuple(
                 groupArray(
                   tuple(
-                    "_row"."_field_trackId",
-                    "_row"."_field_name",
-                    "_row"."_field_unitPrice"
+                    "_row"."_field_trackId" AS "trackId",
+                    "_row"."_field_name" AS "name",
+                    "_row"."_field_unitPrice" AS "unitPrice"
                   )
-                )
+                ) AS "rows"
               ) AS "_rowset",
               "_row"."_relkey_AlbumId" AS "_relkey_AlbumId"
             FROM

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Parameterized SQL@02_relationships_05_traverse_relationship_in_predicate.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Parameterized SQL@02_relationships_05_traverse_relationship_in_predicate.request.json.snap
@@ -18,12 +18,12 @@ FROM
       tuple(
         groupArray(
           tuple(
-            "_row"."_field_albumId",
-            "_row"."_field_artistId",
-            "_row"."_field_title",
-            "_row"."_field_Tracks"
+            "_row"."_field_albumId" AS "albumId",
+            "_row"."_field_artistId" AS "artistId",
+            "_row"."_field_title" AS "title",
+            "_row"."_field_Tracks" AS "Tracks"
           )
-        )
+        ) AS "rows"
       ) AS "_rowset"
     FROM
       (
@@ -39,11 +39,11 @@ FROM
               tuple(
                 groupArray(
                   tuple(
-                    "_row"."_field_trackId",
-                    "_row"."_field_name",
-                    "_row"."_field_unitPrice"
+                    "_row"."_field_trackId" AS "trackId",
+                    "_row"."_field_name" AS "name",
+                    "_row"."_field_unitPrice" AS "unitPrice"
                   )
-                )
+                ) AS "rows"
               ) AS "_rowset",
               "_row"."_relkey_AlbumId" AS "_relkey_AlbumId"
             FROM

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Parameterized SQL@03_variables_01_simple_predicate.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Parameterized SQL@03_variables_01_simple_predicate.request.json.snap
@@ -25,11 +25,11 @@ FROM
       tuple(
         groupArray(
           tuple(
-            "_row"."_field_albumId",
-            "_row"."_field_artistId",
-            "_row"."_field_title"
+            "_row"."_field_albumId" AS "albumId",
+            "_row"."_field_artistId" AS "artistId",
+            "_row"."_field_title" AS "title"
           )
-        )
+        ) AS "rows"
       ) AS "_rowset",
       "_row"."_varset_id" AS "_varset_id"
     FROM

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Parameterized SQL@03_variables_02_empty_variable_sets.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Parameterized SQL@03_variables_02_empty_variable_sets.request.json.snap
@@ -25,11 +25,11 @@ FROM
       tuple(
         groupArray(
           tuple(
-            "_row"."_field_albumId",
-            "_row"."_field_artistId",
-            "_row"."_field_title"
+            "_row"."_field_albumId" AS "albumId",
+            "_row"."_field_artistId" AS "artistId",
+            "_row"."_field_title" AS "title"
           )
-        )
+        ) AS "rows"
       ) AS "_rowset",
       "_row"."_varset_id" AS "_varset_id"
     FROM

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Parameterized SQL@03_variables_03_single_set.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__chinook Parameterized SQL@03_variables_03_single_set.request.json.snap
@@ -25,11 +25,11 @@ FROM
       tuple(
         groupArray(
           tuple(
-            "_row"."_field_albumId",
-            "_row"."_field_artistId",
-            "_row"."_field_title"
+            "_row"."_field_albumId" AS "albumId",
+            "_row"."_field_artistId" AS "artistId",
+            "_row"."_field_title" AS "title"
           )
-        )
+        ) AS "rows"
       ) AS "_rowset",
       "_row"."_varset_id" AS "_varset_id"
     FROM

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__complex_columns Inlined SQL@01_bind_complex_parameters.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__complex_columns Inlined SQL@01_bind_complex_parameters.request.json.snap
@@ -15,7 +15,9 @@ SELECT
 FROM
   (
     SELECT
-      tuple(groupArray(tuple("_row"."_field_field1"))) AS "_rowset"
+      tuple(
+        groupArray(tuple("_row"."_field_field1" AS "field1")) AS "rows"
+      ) AS "_rowset"
     FROM
       (
         SELECT

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__complex_columns Inlined SQL@01_complex_parameters_01_bind.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__complex_columns Inlined SQL@01_complex_parameters_01_bind.request.json.snap
@@ -15,7 +15,9 @@ SELECT
 FROM
   (
     SELECT
-      tuple(groupArray(tuple("_row"."_field_field1"))) AS "_rowset"
+      tuple(
+        groupArray(tuple("_row"."_field_field1" AS "field1")) AS "rows"
+      ) AS "_rowset"
     FROM
       (
         SELECT

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__complex_columns Inlined SQL@01_complex_parameters_02_variables.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__complex_columns Inlined SQL@01_complex_parameters_02_variables.request.json.snap
@@ -25,7 +25,9 @@ FROM
   "_vars" AS "_vars"
   LEFT JOIN (
     SELECT
-      tuple(groupArray(tuple("_row"."_field_field1"))) AS "_rowset",
+      tuple(
+        groupArray(tuple("_row"."_field_field1" AS "field1")) AS "rows"
+      ) AS "_rowset",
       "_row"."_varset_id" AS "_varset_id"
     FROM
       (

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__complex_columns Inlined SQL@02_column_accessor_01_generate_column_accessor.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__complex_columns Inlined SQL@02_column_accessor_01_generate_column_accessor.request.json.snap
@@ -15,7 +15,9 @@ SELECT
 FROM
   (
     SELECT
-      tuple(groupArray(tuple("_row"."_field_field1"))) AS "_rowset"
+      tuple(
+        groupArray(tuple("_row"."_field_field1" AS "field1")) AS "rows"
+      ) AS "_rowset"
     FROM
       (
         SELECT

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__complex_columns Inlined SQL@02_column_accessor_02_skip_if_not_required.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__complex_columns Inlined SQL@02_column_accessor_02_skip_if_not_required.request.json.snap
@@ -15,7 +15,9 @@ SELECT
 FROM
   (
     SELECT
-      tuple(groupArray(tuple("_row"."_field_field1"))) AS "_rowset"
+      tuple(
+        groupArray(tuple("_row"."_field_field1" AS "field1")) AS "rows"
+      ) AS "_rowset"
     FROM
       (
         SELECT

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__complex_columns Inlined SQL@02_column_accessor_03_support_relationships_on_nested_field.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__complex_columns Inlined SQL@02_column_accessor_03_support_relationships_on_nested_field.request.json.snap
@@ -17,8 +17,11 @@ FROM
     SELECT
       tuple(
         groupArray(
-          tuple("_row"."_field_field1", "_row"."_field_field2")
-        )
+          tuple(
+            "_row"."_field_field1" AS "field1",
+            "_row"."_field_field2" AS "field2"
+          )
+        ) AS "rows"
       ) AS "_rowset"
     FROM
       (
@@ -35,7 +38,9 @@ FROM
           "Schema1"."Table1" AS "_origin"
           LEFT JOIN (
             SELECT
-              tuple(groupArray(tuple("_row"."_field_name"))) AS "_rowset",
+              tuple(
+                groupArray(tuple("_row"."_field_name" AS "name")) AS "rows"
+              ) AS "_rowset",
               "_row"."_relkey_Id" AS "_relkey_Id"
             FROM
               (

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__complex_columns Inlined SQL@02_column_accessor_05_complex_example.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__complex_columns Inlined SQL@02_column_accessor_05_complex_example.request.json.snap
@@ -17,8 +17,11 @@ FROM
     SELECT
       tuple(
         groupArray(
-          tuple("_row"."_field_field1", "_row"."_field_field2")
-        )
+          tuple(
+            "_row"."_field_field1" AS "field1",
+            "_row"."_field_field2" AS "field2"
+          )
+        ) AS "rows"
       ) AS "_rowset"
     FROM
       (
@@ -39,7 +42,9 @@ FROM
           "Schema1"."Table1" AS "_origin"
           LEFT JOIN (
             SELECT
-              tuple(groupArray(tuple("_row"."_field_name"))) AS "_rowset",
+              tuple(
+                groupArray(tuple("_row"."_field_name" AS "name")) AS "rows"
+              ) AS "_rowset",
               "_row"."_relkey_Id" AS "_relkey_Id"
             FROM
               (

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__complex_columns Inlined SQL@02_column_accessor_06_no_useless_nested_accessors.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__complex_columns Inlined SQL@02_column_accessor_06_no_useless_nested_accessors.request.json.snap
@@ -17,8 +17,11 @@ FROM
     SELECT
       tuple(
         groupArray(
-          tuple("_row"."_field_field1", "_row"."_field_field2")
-        )
+          tuple(
+            "_row"."_field_field1" AS "field1",
+            "_row"."_field_field2" AS "field2"
+          )
+        ) AS "rows"
       ) AS "_rowset"
     FROM
       (

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__complex_columns Inlined SQL@02_variables_with_complex_parameters.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__complex_columns Inlined SQL@02_variables_with_complex_parameters.request.json.snap
@@ -25,7 +25,9 @@ FROM
   "_vars" AS "_vars"
   LEFT JOIN (
     SELECT
-      tuple(groupArray(tuple("_row"."_field_field1"))) AS "_rowset",
+      tuple(
+        groupArray(tuple("_row"."_field_field1" AS "field1")) AS "rows"
+      ) AS "_rowset",
       "_row"."_varset_id" AS "_varset_id"
     FROM
       (

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__complex_columns Parameterized SQL@01_bind_complex_parameters.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__complex_columns Parameterized SQL@01_bind_complex_parameters.request.json.snap
@@ -15,7 +15,9 @@ SELECT
 FROM
   (
     SELECT
-      tuple(groupArray(tuple("_row"."_field_field1"))) AS "_rowset"
+      tuple(
+        groupArray(tuple("_row"."_field_field1" AS "field1")) AS "rows"
+      ) AS "_rowset"
     FROM
       (
         SELECT

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__complex_columns Parameterized SQL@01_complex_parameters_01_bind.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__complex_columns Parameterized SQL@01_complex_parameters_01_bind.request.json.snap
@@ -15,7 +15,9 @@ SELECT
 FROM
   (
     SELECT
-      tuple(groupArray(tuple("_row"."_field_field1"))) AS "_rowset"
+      tuple(
+        groupArray(tuple("_row"."_field_field1" AS "field1")) AS "rows"
+      ) AS "_rowset"
     FROM
       (
         SELECT

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__complex_columns Parameterized SQL@01_complex_parameters_02_variables.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__complex_columns Parameterized SQL@01_complex_parameters_02_variables.request.json.snap
@@ -22,7 +22,9 @@ FROM
   "_vars" AS "_vars"
   LEFT JOIN (
     SELECT
-      tuple(groupArray(tuple("_row"."_field_field1"))) AS "_rowset",
+      tuple(
+        groupArray(tuple("_row"."_field_field1" AS "field1")) AS "rows"
+      ) AS "_rowset",
       "_row"."_varset_id" AS "_varset_id"
     FROM
       (

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__complex_columns Parameterized SQL@02_variables_with_complex_parameters.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__complex_columns Parameterized SQL@02_variables_with_complex_parameters.request.json.snap
@@ -22,7 +22,9 @@ FROM
   "_vars" AS "_vars"
   LEFT JOIN (
     SELECT
-      tuple(groupArray(tuple("_row"."_field_field1"))) AS "_rowset",
+      tuple(
+        groupArray(tuple("_row"."_field_field1" AS "field1")) AS "rows"
+      ) AS "_rowset",
       "_row"."_varset_id" AS "_varset_id"
     FROM
       (

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__star_schema Inlined SQL@01_native_query.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__star_schema Inlined SQL@01_native_query.request.json.snap
@@ -15,7 +15,9 @@ SELECT
 FROM
   (
     SELECT
-      tuple(groupArray(tuple("_row"."_field_revenue"))) AS "_rowset"
+      tuple(
+        groupArray(tuple("_row"."_field_revenue" AS "revenue")) AS "rows"
+      ) AS "_rowset"
     FROM
       (
         SELECT

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__star_schema Inlined SQL@02_native_query_with_predicate.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__star_schema Inlined SQL@02_native_query_with_predicate.request.json.snap
@@ -15,7 +15,9 @@ SELECT
 FROM
   (
     SELECT
-      tuple(groupArray(tuple("_row"."_field_revenue"))) AS "_rowset"
+      tuple(
+        groupArray(tuple("_row"."_field_revenue" AS "revenue")) AS "rows"
+      ) AS "_rowset"
     FROM
       (
         SELECT

--- a/crates/ndc-clickhouse/tests/snapshots/query_builder__star_schema Parameterized SQL@02_native_query_with_predicate.request.json.snap
+++ b/crates/ndc-clickhouse/tests/snapshots/query_builder__star_schema Parameterized SQL@02_native_query_with_predicate.request.json.snap
@@ -15,7 +15,9 @@ SELECT
 FROM
   (
     SELECT
-      tuple(groupArray(tuple("_row"."_field_revenue"))) AS "_rowset"
+      tuple(
+        groupArray(tuple("_row"."_field_revenue" AS "revenue")) AS "rows"
+      ) AS "_rowset"
     FROM
       (
         SELECT


### PR DESCRIPTION
Our generated SQL casts anonymous tuples to named tuples at the very top:
```sql
-- cast the anonymou tuple to a named tuple, relying on position
SELECT cast(
  _rowset._rowset,
  'tuple(foo String, bar String)'
) FROM (
  -- create anonymous, positional tuple
  -- starting in 24.7, creates a named tuple with fields _field_foo and _field_bar
  SELECT tuple(
    _row._field_foo,
    _row._field_bar
  ) AS _rowset
  FROM (
    SELECT
      -- fields aliased with a namespace
      -- required as we may select fields for other reasons
      -- (eg. ordering, relationships) 
      'foo' AS _field_foo,
      'bar' AS _field_bar
  ) AS _row
) AS _rowset
```

The above fails starting in [ClickHouse 24.7](https://clickhouse.com/docs/en/whats-new/changelog#backward-incompatible-change-2) due to a breaking change:
> Function tuple will now try to construct named tuples in query (controlled by enable_named_columns_in_function_tuple). Introduce function tupleNames to extract names from tuples.

This manifests is a very weird way: when casting, we end up getting the default value for the data type, because we cannot fetch the correct column in the tuple.

Turns out, it's possible to alias fields when creating a named tuple, to set the names for the tuple:
```sql
-- casting now works
SELECT cast(
  _rowset._rowset,
  'tuple(foo String, bar String)'
) FROM (
  -- create a named tuple
  SELECT tuple(
    _row._field_foo as foo,
    _row._field_bar as bar
  ) AS _rowset
  FROM (
    SELECT
      'foo' AS _field_foo,
      'bar' AS _field_bar
  ) AS _row
) AS _rowset
```