### PR TITLE
Rust SDK upgrade

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+source_env_if_exists .envrc.local

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /.idea
 .env
 /config
+
+# direnv
+.envrc.local

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
+name = "async-compression"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddb939d66e4ae03cee6091612804ba446b12878410cfa17f785f4dd67d4014e8"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +294,8 @@ version = "1.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "755717a7de9ec452bf7f3f1a3099085deabd7f2962b861dae91ecd7a365903d2"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -1148,6 +1165,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1323,8 +1349,8 @@ dependencies = [
 
 [[package]]
 name = "ndc-models"
-version = "0.1.6"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.6#d1be19e9cdd86ac7b6ad003ff82b7e5b4e96b84f"
+version = "0.2.4"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.2.4#df67fa6469431f9304aac9c237e9d2327d20da20"
 dependencies = [
  "indexmap 2.7.1",
  "ref-cast",
@@ -1337,8 +1363,8 @@ dependencies = [
 
 [[package]]
 name = "ndc-sdk"
-version = "0.5.0"
-source = "git+https://github.com/hasura/ndc-sdk-rs?tag=v0.5.0#15840777b3700112a508bb116f1131804e800c13"
+version = "0.8.0"
+source = "git+https://github.com/hasura/ndc-sdk-rs?tag=v0.8.0#0c93ded023767c8402ace015aff5023115d8dcb6"
 dependencies = [
  "async-trait",
  "axum",
@@ -1355,6 +1381,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prometheus",
  "reqwest 0.11.27",
+ "semver",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
@@ -1367,8 +1394,8 @@ dependencies = [
 
 [[package]]
 name = "ndc-sdk-core"
-version = "0.5.0"
-source = "git+https://github.com/hasura/ndc-sdk-rs?tag=v0.5.0#15840777b3700112a508bb116f1131804e800c13"
+version = "0.8.0"
+source = "git+https://github.com/hasura/ndc-sdk-rs?tag=v0.8.0#0c93ded023767c8402ace015aff5023115d8dcb6"
 dependencies = [
  "async-trait",
  "axum",
@@ -2251,6 +2278,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+
+[[package]]
 name = "serde"
 version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2810,6 +2843,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
+ "async-compression",
  "bitflags 2.8.0",
  "bytes",
  "futures-core",
@@ -2819,6 +2853,8 @@ dependencies = [
  "http-range-header",
  "mime",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3493,4 +3529,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.15+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ package.version = "1.1.0"
 package.edition = "2021"
 
 [workspace.dependencies]
-ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.6" }
-ndc-sdk = { git = "https://github.com/hasura/ndc-sdk-rs", tag = "v0.5.0", package = "ndc-sdk", features = [
+ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.4" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-sdk-rs", tag = "v0.8.0", package = "ndc-sdk", features = [
   "rustls",
 ], default-features = false }
-ndc-sdk-core = { git = "https://github.com/hasura/ndc-sdk-rs", tag = "v0.5.0", package = "ndc-sdk-core", default-features = false }
+ndc-sdk-core = { git = "https://github.com/hasura/ndc-sdk-rs", tag = "v0.8.0", package = "ndc-sdk-core", default-features = false }
 
 # insta performs better in release mode
 [profile.dev.package]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 bytes = "1.6.0"
 peg = "0.8.2"
 indexmap = "2.1.0"
-ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.6" }
+ndc-models = { workspace = true } 
 reqwest = { version = "0.12.3", features = [
     "json",
     "rustls-tls",

--- a/crates/common/src/capabilities.rs
+++ b/crates/common/src/capabilities.rs
@@ -1,21 +1,29 @@
 use ndc_models::{
-    Capabilities, CapabilitiesResponse, ExistsCapabilities, LeafCapability, MutationCapabilities,
-    NestedFieldCapabilities, QueryCapabilities, RelationshipCapabilities, VERSION,
+    AggregateCapabilities, Capabilities, CapabilitiesResponse, ExistsCapabilities, LeafCapability,
+    MutationCapabilities, NestedFieldCapabilities, QueryCapabilities, RelationshipCapabilities,
+    VERSION,
 };
 
 pub fn capabilities() -> Capabilities {
     Capabilities {
         query: QueryCapabilities {
-            aggregates: Some(LeafCapability {}),
+            aggregates: Some(AggregateCapabilities {
+                filter_by: None,
+                group_by: None,
+            }),
             variables: Some(LeafCapability {}),
             explain: Some(LeafCapability {}),
             nested_fields: NestedFieldCapabilities {
                 filter_by: None,
                 order_by: None,
                 aggregates: None,
+                nested_collections: None,
             },
             exists: ExistsCapabilities {
                 nested_collections: None,
+                unrelated: None,
+                named_scopes: None,
+                nested_scalar_collections: None,
             },
         },
         mutation: MutationCapabilities {
@@ -25,7 +33,10 @@ pub fn capabilities() -> Capabilities {
         relationships: Some(RelationshipCapabilities {
             relation_comparisons: Some(LeafCapability {}),
             order_by_aggregate: Some(LeafCapability {}),
+            nested: None,
         }),
+        relational_query: None,
+        relational_mutation: None,
     }
 }
 

--- a/crates/common/src/schema.rs
+++ b/crates/common/src/schema.rs
@@ -56,6 +56,7 @@ pub fn schema_response(configuration: &ServerConfig) -> models::SchemaResponse {
             models::ObjectType {
                 description: table_type.comment.to_owned(),
                 fields: fields.into_iter().collect(),
+                foreign_keys: BTreeMap::new(),
             },
         );
     }
@@ -117,6 +118,7 @@ pub fn schema_response(configuration: &ServerConfig) -> models::SchemaResponse {
         .map(|(table_alias, table_config)| models::CollectionInfo {
             name: table_alias.to_owned(),
             description: table_config.comment.to_owned(),
+            relational_mutations: None,
             arguments: table_config
                 .arguments
                 .iter()
@@ -148,7 +150,6 @@ pub fn schema_response(configuration: &ServerConfig) -> models::SchemaResponse {
                     )])
                 },
             ),
-            foreign_keys: BTreeMap::new(),
         });
 
     let query_collections = configuration
@@ -195,7 +196,7 @@ pub fn schema_response(configuration: &ServerConfig) -> models::SchemaResponse {
                 arguments,
                 collection_type: query_config.return_type.to_owned(),
                 uniqueness_constraints: BTreeMap::new(),
-                foreign_keys: BTreeMap::new(),
+                relational_mutations: None,
             }
         });
 
@@ -209,5 +210,7 @@ pub fn schema_response(configuration: &ServerConfig) -> models::SchemaResponse {
         collections,
         functions: vec![],
         procedures: vec![],
+        capabilities: None,
+        request_arguments: None,
     }
 }

--- a/crates/common/src/schema/type_definition.rs
+++ b/crates/common/src/schema/type_definition.rs
@@ -48,13 +48,14 @@ impl ClickHouseScalar {
     fn type_definition(&self) -> models::ScalarType {
         models::ScalarType {
             representation: self.json_representation(),
+            extraction_functions: BTreeMap::new(),
             aggregate_functions: self
                 .aggregate_functions()
                 .into_iter()
                 .map(|(function, result_type)| {
                     (
                         function.to_string().into(),
-                        models::AggregateFunctionDefinition {
+                        models::AggregateFunctionDefinition::Custom {
                             result_type: models::Type::Named {
                                 name: result_type.to_string().into(),
                             },
@@ -104,46 +105,46 @@ impl ClickHouseScalar {
                 .collect(),
         }
     }
-    fn json_representation(&self) -> Option<models::TypeRepresentation> {
+    fn json_representation(&self) -> models::TypeRepresentation {
         use models::TypeRepresentation as Rep;
         match &self.0 {
-            ClickHouseDataType::Bool => Some(Rep::Boolean),
-            ClickHouseDataType::String => Some(Rep::String),
-            ClickHouseDataType::UInt8 => Some(Rep::Int16), // Unsigned int8 fits into signed int16
-            ClickHouseDataType::UInt16 => Some(Rep::Int32), // Unsigned int16 fits into signed int32
-            ClickHouseDataType::UInt32 => Some(Rep::Int64), // Unsigned int32 fits into signed int64
-            ClickHouseDataType::UInt64 => Some(Rep::BigInteger), // Unsigned int64 will have to go into BigInteger
-            ClickHouseDataType::UInt128 => Some(Rep::BigInteger), // Unsigned int128 will have to go into BigInteger
-            ClickHouseDataType::UInt256 => Some(Rep::BigInteger), // Unsigned int256 will have to go into BigInteger
-            ClickHouseDataType::Int8 => Some(Rep::Int8),
-            ClickHouseDataType::Int16 => Some(Rep::Int16),
-            ClickHouseDataType::Int32 => Some(Rep::Int32),
-            ClickHouseDataType::Int64 => Some(Rep::Int64),
-            ClickHouseDataType::Int128 => Some(Rep::BigInteger),
-            ClickHouseDataType::Int256 => Some(Rep::BigInteger),
-            ClickHouseDataType::Float32 => Some(Rep::Float32),
-            ClickHouseDataType::Float64 => Some(Rep::Float64),
-            ClickHouseDataType::Decimal { .. } => Some(Rep::BigDecimal),
-            ClickHouseDataType::Decimal32 { .. } => Some(Rep::String),
-            ClickHouseDataType::Decimal64 { .. } => Some(Rep::String),
-            ClickHouseDataType::Decimal128 { .. } => Some(Rep::String),
-            ClickHouseDataType::Decimal256 { .. } => Some(Rep::String),
-            ClickHouseDataType::Date => Some(Rep::String),
-            ClickHouseDataType::Date32 => Some(Rep::String),
-            ClickHouseDataType::DateTime { .. } => Some(Rep::String),
-            ClickHouseDataType::DateTime64 { .. } => Some(Rep::String),
-            ClickHouseDataType::Uuid => Some(Rep::String),
-            ClickHouseDataType::IPv4 => Some(Rep::String),
-            ClickHouseDataType::IPv6 => Some(Rep::String),
+            ClickHouseDataType::Bool => Rep::Boolean,
+            ClickHouseDataType::String => Rep::String,
+            ClickHouseDataType::UInt8 => Rep::Int16, // Unsigned int8 fits into signed int16
+            ClickHouseDataType::UInt16 => Rep::Int32, // Unsigned int16 fits into signed int32
+            ClickHouseDataType::UInt32 => Rep::Int64, // Unsigned int32 fits into signed int64
+            ClickHouseDataType::UInt64 => Rep::BigInteger, // Unsigned int64 will have to go into BigInteger
+            ClickHouseDataType::UInt128 => Rep::BigInteger, // Unsigned int128 will have to go into BigInteger
+            ClickHouseDataType::UInt256 => Rep::BigInteger, // Unsigned int256 will have to go into BigInteger
+            ClickHouseDataType::Int8 => Rep::Int8,
+            ClickHouseDataType::Int16 => Rep::Int16,
+            ClickHouseDataType::Int32 => Rep::Int32,
+            ClickHouseDataType::Int64 => Rep::Int64,
+            ClickHouseDataType::Int128 => Rep::BigInteger,
+            ClickHouseDataType::Int256 => Rep::BigInteger,
+            ClickHouseDataType::Float32 => Rep::Float32,
+            ClickHouseDataType::Float64 => Rep::Float64,
+            ClickHouseDataType::Decimal { .. } => Rep::BigDecimal,
+            ClickHouseDataType::Decimal32 { .. } => Rep::String,
+            ClickHouseDataType::Decimal64 { .. } => Rep::String,
+            ClickHouseDataType::Decimal128 { .. } => Rep::String,
+            ClickHouseDataType::Decimal256 { .. } => Rep::String,
+            ClickHouseDataType::Date => Rep::String,
+            ClickHouseDataType::Date32 => Rep::String,
+            ClickHouseDataType::DateTime { .. } => Rep::String,
+            ClickHouseDataType::DateTime64 { .. } => Rep::String,
+            ClickHouseDataType::Uuid => Rep::String,
+            ClickHouseDataType::IPv4 => Rep::String,
+            ClickHouseDataType::IPv6 => Rep::String,
             ClickHouseDataType::Enum(variants) => {
                 let variants = variants
                     .iter()
                     .map(|(SingleQuotedString(variant), _)| variant.to_owned())
                     .collect();
 
-                Some(Rep::Enum { one_of: variants })
+                Rep::Enum { one_of: variants }
             }
-            _ => None,
+            _ => Rep::JSON,
         }
     }
     fn aggregate_functions(
@@ -662,6 +663,7 @@ impl ClickHouseTypeDefinition {
                     models::ObjectType {
                         description: None,
                         fields: object_type_fields.into_iter().collect(),
+                        foreign_keys: BTreeMap::new(),
                     },
                 ));
 


### PR DESCRIPTION
Started this because we connector name/version in traces, but first we need to update to `ndc_models 0.2.4`, so there's a bit more to do here.