### PR TITLE
ci: disable trivy vulnerability scanning

### DIFF
--- a/.github/workflows/deploy-stage.yaml
+++ b/.github/workflows/deploy-stage.yaml
@@ -49,15 +49,15 @@ jobs:
           push: ${{ startsWith(github.ref, 'refs/tags/v') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.35.0
-        with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
-          format: json
-          output: trivy-results.json
-          severity: CRITICAL,HIGH
-          scanners: vuln
-
+#       - name: Run Trivy vulnerability scanner
+#         uses: aquasecurity/trivy-action@v0.35.0
+#         with:
+#           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+#           format: json
+#           output: trivy-results.json
+#           severity: CRITICAL,HIGH
+#           scanners: vuln
+# 
   build-cli-binaries:
     name: build the CLI binaries
     strategy:


### PR DESCRIPTION
## Summary
- Disable Trivy vulnerability scanning steps/jobs in CI pipelines
- Trivy scan steps have been commented out from workflow/pipeline files

## Test plan
- [ ] Verify CI pipelines still run successfully without trivy steps
- [ ] Confirm no downstream jobs depend on the disabled scan steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)