### PR TITLE
chore(images): migrate base images to private -stable aliases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY Cargo.lock ./
 COPY crates crates
 RUN cargo build --locked --profile release --package ndc-clickhouse
 
-FROM ubuntu:24.04 AS runtime
+FROM us-docker.pkg.dev/hasura-container-images/external-images/docker.io/library/ubuntu:24.04-stable AS runtime
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=builder /app/target/release/ndc-clickhouse /usr/local/bin


### PR DESCRIPTION
## Summary

Re-homes base images to Hasura's private Artifact Registry `us-docker.pkg.dev/hasura-container-images/external-images` via floating `-stable` aliases. Per Hasura policy, every container deployed in Hasura infra must be pulled from this private registry rather than upstream registries (Docker Hub, ghcr.io, gcr.io, quay.io, etc.).

The `-stable` aliases are floating: they auto-advance to the latest patched digest of the same version line, so security patches are picked up without further version bumps.

## Exact FROM swaps

### `Dockerfile`
- `FROM ubuntu:24.04 AS runtime` → `FROM us-docker.pkg.dev/hasura-container-images/external-images/docker.io/library/ubuntu:24.04-stable AS runtime`

The `AS runtime` stage suffix is preserved; only the image reference was changed. No other lines, FROM statements, or versions were touched.

## Notes

This is part of an org-wide **Phase 1** migration: exact-match swaps only (same version/tag line), no version bumps or reformatting.