### PR TITLE
chore(images): migrate OS base to private -stable alias

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY Cargo.lock ./
 COPY crates crates
 RUN cargo build --locked --profile release --package ndc-clickhouse
 
-FROM ubuntu:24.04 AS runtime
+FROM us-docker.pkg.dev/hasura-container-images/external-images/docker.io/library/ubuntu:24.04-stable AS runtime
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=builder /app/target/release/ndc-clickhouse /usr/local/bin


### PR DESCRIPTION
## What & why

This re-homes the connector's **runtime/OS base** from the upstream Docker Hub image to Hasura's private Artifact Registry (`us-docker.pkg.dev/hasura-container-images/external-images`), using the floating **`-stable`** alias.

Per Hasura policy, every container deployed in Hasura infra must be pulled from the private Artifact Registry, not from upstream registries (Docker Hub etc.). Using the `-stable` floating alias (same version line, auto-patched) means rebuilds automatically inherit the latest patched base for **CVE reduction**, while remaining **registry-compliant**.

## Exact `FROM` swaps

| Stage | Before | After |
|-------|--------|-------|
| `runtime` | `ubuntu:24.04` | `us-docker.pkg.dev/hasura-container-images/external-images/docker.io/library/ubuntu:24.04-stable` |

Only the image reference changed; the `FROM ` keyword and the ` AS runtime` stage alias are preserved exactly.

## Out of scope

The builder `rust:` stage (`FROM rust:1.88.0 as chef`) is **intentionally left unchanged** in this PR — there is no `rust:1.88-stable` private alias, and floating it would be a version bump. Local-stage `FROM` lines (`chef`, `planner`, `builder`) are untouched.

## Note

This ties the runtime base pull to the private AR — external/OSS builds will need access to that registry to build the runtime image.